### PR TITLE
build: fix package types exposing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Vite resolver for TypeScript compilerOptions.paths",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "author": "aleclarson",
   "repository": "aleclarson/vite-tsconfig-paths",
   "license": "MIT",


### PR DESCRIPTION
I added the `types` field into `package.json`. Without it, the `index.d.ts` file goes unnoticed.

See this on official TypeScript docs: [Including declarations in your npm package](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package).