### PR TITLE
fix: support .svelte when checkJs is true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export default (opts: PluginOptions = {}): Plugin => ({
       )
 
       const { checkJs } = loadCompilerOptions(config.configFileAbsolutePath)
-      const importerExtRE = checkJs ? /\.(vue|mdx|mjs|[jt]sx?)$/ : /\.tsx?$/
+      const importerExtRE = checkJs ? /\.(vue|svelte|mdx|mjs|[jt]sx?)$/ : /\.tsx?$/
 
       const resolved = new Map<string, string>()
       this.resolveId = async function (id, importer) {


### PR DESCRIPTION
I've added `.svelte` files to the regular expression checking for filetypes to check.

For me this fixes https://github.com/aleclarson/vite-tsconfig-paths/issues/11