### PR TITLE
fix: stop caching `viteResolve` in buildStart

### DIFF
--- a/spec/resolver.ts
+++ b/spec/resolver.ts
@@ -18,9 +18,9 @@ export function getResolver(opts?: PluginOptions) {
   }
 
   plugin.configResolved!({ root: __dirname } as any)
-  plugin.buildStart!.call(container as any, {} as any)
+  Object.assign(plugin, container)
 
-  const resolveId = plugin.resolveId as (
+  const resolveId = plugin.resolveId!.bind(plugin as any) as (
     id: string,
     importer?: string
   ) => Promise<string | undefined>


### PR DESCRIPTION
This fixes issue #31.

It seems that the issue here was that `resolveId` is being called before `buildStart`, when a `node_modules/.vite` cache doesn't exist.

Further investigation revealed that we can't wait for `buildStart` because it causes the build to lock up. We're also unable to cache the `viteResolve` function, as the result seems to change as the build progresses.

The fix involves just creating a new `viteResolve` function on every call to `resolveId`. This may cause a slight degradation in performance, but it doesn't seem noticeable to me.