### PR TITLE
fix: add missing type entry to pkg.exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   },


### PR DESCRIPTION
See: https://github.com/aleclarson/vite-tsconfig-paths/issues/62

Needed for Typescript 4.7 in moduleResolution Node16 mode.

See also: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/
and https://www.typescriptlang.org/docs/handbook/esm-node.html (example at the end of the page)