### PR TITLE
fix: dont exit if files array is empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,6 @@ export default (opts: PluginOptions = {}): Plugin => {
     // Empty `files` array means no files are included.
     if (config.files?.length == 0) {
       debug(`[!] files array is empty: "${configPath}"`)
-      return null
     }
 
     const options = config.compilerOptions


### PR DESCRIPTION
Version `4.0.1` is not working with Nx. This specific addition broke it. If this is removed, then it works.

Explanation:

Version `4.0.0` is working by only setting `root` to the root of the project. Version `4.0.1` does not work only with `root`, it also needs `projects: ['tsconfig.base.json']` to be set.

Reproduction repo: https://github.com/mandarini/test-new-tsconfig-paths/tree/test/4.0.1