### PR TITLE
chore: remove `peerDependencies` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "vite": "*",
     "vite-tsconfig-paths": "link:."
   },
-  "peerDependencies": {
-    "vite": ">2.0.0-0"
-  },
   "keywords": [
     "vite",
     "resolver",


### PR DESCRIPTION
This PR removes `peerDependencies` from `package.json` to close #89.