### PR TITLE
feat(perf): leverage tsconfk caching to skip redundant work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export default (opts: PluginOptions = {}): Plugin => {
       let firstError: any
 
       const parseOptions = {
+        cache: new Map(),
         resolveWithEmptyIfConfigNotFound: true,
       } satisfies import('tsconfck').TSConfckParseOptions
 


### PR DESCRIPTION
This one-line change can speed up vite-tsconfig-paths significantly, especially on large projects.

Tested with a few thousand TypeScript projects referencing each other: 52s (before) -> 23s (after).