### PR TITLE
fix: upgrade tsconfck to fix bug that could cause a deadlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "globrex": "^0.1.2",
-    "tsconfck": "^3.0.1"
+    "tsconfck": "^3.0.3"
   },
   "devDependencies": {
     "@alloc/fast-rimraf": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       tsconfck:
-        specifier: ^3.0.1
-        version: 3.0.1(typescript@4.9.3)
+        specifier: ^3.0.3
+        version: 3.0.3(typescript@4.9.3)
     devDependencies:
       '@alloc/fast-rimraf':
         specifier: ^1.0.8
@@ -4855,8 +4855,8 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tsconfck@3.0.1(typescript@4.9.3):
-    resolution: {integrity: sha512-7ppiBlF3UEddCLeI1JRx5m2Ryq+xk4JrZuq4EuYXykipebaq1dV0Fhgr1hb7CkmHt32QSgOZlcqVLEtHBG4/mg==}
+  /tsconfck@3.0.3(typescript@4.9.3):
+    resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
The issue of https://github.com/aleclarson/vite-tsconfig-paths/issues/132 has been fixed via https://github.com/dominikg/tsconfck/pull/165 and which has been delivered into [tsconfck@v3.0.3](https://github.com/dominikg/tsconfck/pull/166).