### PR TITLE
chore: drop CJS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Give [`vite`] the ability to resolve imports using TypeScript's path mapping.
 
 1. Install as dev dependency
 
-2. Inject `vite-tsconfig-paths` using the `vite.config.ts` module
+2. Ensure the project either has `"type": "module"` set or that the Vite config is renamed to `vite.config.mjs` / `vite.config.mts` depending on whether TypeScript is used
+
+3. Inject `vite-tsconfig-paths` in the Vite config
 
    ```ts
    import { defineConfig } from 'vite'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf dist && git checkout HEAD dist",
     "dev": "yarn bundle --watch",
     "build": "yarn clean && yarn bundle",
-    "bundle": "tsup-node src/index.ts --sourcemap --dts --format cjs,esm",
+    "bundle": "tsup-node src/index.ts --sourcemap --dts --format esm",
     "prepare": "yarn build",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -2,14 +2,10 @@
   "name": "vite-tsconfig-paths",
   "version": "4.3.2",
   "description": "Vite resolver for TypeScript compilerOptions.paths",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "type": "module",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.mjs"
   },
   "author": "aleclarson",
   "repository": "aleclarson/vite-tsconfig-paths",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/index.d.ts",
-    "default": "./dist/index.mjs"
+    "default": "./dist/index.js"
   },
   "author": "aleclarson",
   "repository": "aleclarson/vite-tsconfig-paths",


### PR DESCRIPTION
closes https://github.com/aleclarson/vite-tsconfig-paths/issues/140

Since Vite is dropping its CJS build, there's no reason for this plugin to keep a CJS build as it will no longer be able to be used once Vite completes that move

See https://github.com/vitejs/vite/discussions/13928