### PR TITLE
fix: tolerate `resolveId` calls with win32-style importer path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,11 +162,11 @@ export default (opts: PluginOptions = {}): Plugin => {
           (await this.resolve(id, importer, resolveOptions))?.id
 
         let prevProjectDir: string | undefined
-        let projectDir = dirname(importer)
+        let projectDir = normalizePath(dirname(importer))
 
         // Find the nearest directory with a matching tsconfig file.
         loop: while (projectDir && projectDir != prevProjectDir) {
-          const resolvers = resolversByDir[normalizePath(projectDir)]
+          const resolvers = resolversByDir[projectDir]
           if (resolvers)
             for (const resolve of resolvers) {
               const [resolved, matched] = await resolve(

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export default (opts: PluginOptions = {}): Plugin => {
 
         // Find the nearest directory with a matching tsconfig file.
         loop: while (projectDir && projectDir != prevProjectDir) {
-          const resolvers = resolversByDir[projectDir]
+          const resolvers = resolversByDir[normalizePath(projectDir)]
           if (resolvers)
             for (const resolve of resolvers) {
               const [resolved, matched] = await resolve(


### PR DESCRIPTION
when `vite-tsconfig-paths` work with other plugins on windows

the parameter `importer` of `resolveId hook`  can be windows path and includes `\` char

that will cause `const resolvers = resolversByDir[projectDir]` get `undefined`

---

it should fix some error like `Rollup failed to resolve import` on windows

<https://github.com/aleclarson/vite-tsconfig-paths/issues?q=is%3Aissue+Rollup+failed+to+resolve+import>

other detail see <https://github.com/lisonge/vite-plugin-monkey/issues/186#issuecomment-2353496972>

