### PR TITLE
docs: mention allowJs and loose options earlier in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Give [`vite`] the ability to resolve imports using TypeScript's path mapping.
      plugins: [tsconfigPaths()],
    })
    ```
+4. (optional) ⚠️ To ensure the correct resolution of custom file formats such as `.vue`, `.svelte`, `.mdx` etc using a **custom compiler**, set the `allowJs` option to true in your `tsconfig.json` file. Or enable `loose: true` to resolve all files.
 
 **Note:** You need to restart Vite when you update your `paths` mappings.
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Give [`vite`] the ability to resolve imports using TypeScript's path mapping.
      plugins: [tsconfigPaths()],
    })
    ```
-4. (optional) ⚠️ To ensure the correct resolution of custom file formats such as `.vue`, `.svelte`, `.mdx` etc using a **custom compiler**, set the `allowJs` option to true in your `tsconfig.json` file. Or enable `loose: true` to resolve all files.
 
-**Note:** You need to restart Vite when you update your `paths` mappings.
+4. (optional) ⚠️ To enable path resolution in non-TypeScript modules (e.g. `.vue`, `.svelte`, `.mdx`), you must set the `allowJs` option to true in your `tsconfig.json` file. If that doesn't work, you might need to enable `loose: true` to resolve all files. Note that, due to a Vite limitation, CSS files (and CSS dialects) cannot be resolved with this plugin (see #30).
+
+**Note:** You need to restart Vite when you update your `paths` mappings. This is being tracked in #17 (contributions welcome).
 
 ### Options
 


### PR DESCRIPTION
It's my bad not to read README in detail. As a result, I have spend three hourse to figer out how to support resolve Vue SFC file. 

And the answer is so simple just in README.

I'm using strict Typescript with React when I switched to monorepo and strict Typescript Vue, I made this mistake confidently.    
I checked everything was fine. So I debug into the source code, and find `loose` and `allowJs` options, I'm really stupid.

So, I made this PR, adding **an optional step 4**, to warn others not to make this mistake.
feel free to close for any reason. 🤣 