### PR TITLE
add a fixture with `"paths": { "*": ["./src/*"] }`

### DIFF
--- a/test/__fixtures__/star-path/package.json
+++ b/test/__fixtures__/star-path/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "star-path",
+  "version": "0.0.0"
+}

--- a/test/__fixtures__/star-path/src/lib/module.ts
+++ b/test/__fixtures__/star-path/src/lib/module.ts
@@ -1,0 +1,3 @@
+export const a = 'a'
+
+export const b = 'b'

--- a/test/__fixtures__/star-path/src/lib/package.json
+++ b/test/__fixtures__/star-path/src/lib/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "lib",
+  "version": "0.0.0"
+}

--- a/test/__fixtures__/star-path/src/lib/tsconfig.json
+++ b/test/__fixtures__/star-path/src/lib/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/test/__fixtures__/star-path/src/proj/index.ts
+++ b/test/__fixtures__/star-path/src/proj/index.ts
@@ -1,0 +1,3 @@
+import { a, b } from 'lib/module'
+
+console.log(a, b)

--- a/test/__fixtures__/star-path/src/proj/package.json
+++ b/test/__fixtures__/star-path/src/proj/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "proj",
+  "version": "0.0.0"
+}

--- a/test/__fixtures__/star-path/src/proj/tsconfig.json
+++ b/test/__fixtures__/star-path/src/proj/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/test/__fixtures__/star-path/tsconfig.json
+++ b/test/__fixtures__/star-path/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "rootDir": ".",
+    "paths": {
+      "*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Fixture for the case in #167 

Apologies that this is slightly modified from the original presentation but I believe this is a simpler formulation.

In the original statement, paths was defined in each subproject (e.g. `~/src/*/tsconfig.json`) as `paths: "*": ["../*", "../../*"]`.