### PR TITLE
fix: normalize path separators in tsconfigFile sanity check

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -113,12 +113,12 @@ export function createTsconfigResolvers({
   let onParseError: ((tsconfigFile: string) => void) | undefined
 
   const addProject = (project: Project, data?: Directory) => {
-    const tsconfigFile = project.tsconfigFile
-    const dir = path.normalize(path.dirname(tsconfigFile))
+    const tsconfigFileNormalized = path.normalize(project.tsconfigFile)
+    const dir = path.normalize(path.dirname(tsconfigFileNormalized))
     data ??= directoryCache.get(dir)
 
     // Sanity check
-    if (data?.projects.some((p) => p.tsconfigFile === tsconfigFile)) {
+    if (data?.projects.some((p) => path.normalize(p.tsconfigFile) === tsconfigFileNormalized)) {
       return
     }
 


### PR DESCRIPTION
Fixes an issue where the `p.tsconfigFile === tsconfigFile` sanity check fails due to mismatched path separators (`\` vs `/`) between different operating systems (Windows vs Linux). Normalizing both paths before comparison ensures the check correctly identifies matching files regardless of the OS environment