### PR TITLE
fix: use `path.isAbsolute` when resolving path with `baseUrl`

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -400,7 +400,7 @@ function createResolver(
 
   const resolveWithBaseUrl: InternalResolver | undefined = baseUrl
     ? async (viteResolve, id, importer) => {
-        if (id[0] === '/') {
+        if (path.isAbsolute(id)) {
           return
         }
         const absoluteId = join(baseUrl, id)


### PR DESCRIPTION
Fixes #212.

I've tested this fix in [another reproduction repo](https://github.com/re1sub/issue-1302-repro/tree/main) that was posted in an unrelated issue https://github.com/vanilla-extract-css/vanilla-extract/issues/1302.

I can't really figure out a nice way to reproduce the bug in a test fixture. I'd imagine some kind of custom resolve plugin would do it, but I don't have the time to investigate this any further.