### PR TITLE
fix: resolve aliases from referenced tsconfig projects in sibling directories

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -44,6 +44,7 @@ export function createTsconfigResolvers({
   let initializing: Promise<void> | undefined
   let directoryCache: Map<string, Directory>
   let resolversByProject: WeakMap<Project, Resolver>
+  let unrestrictedResolversByProject: WeakMap<Project, Resolver>
   let isFirstParseError = true
   let hasTypeScriptDep = false
 
@@ -126,6 +127,15 @@ export function createTsconfigResolvers({
     if (project.referenced) {
       project.referenced.forEach((projectRef) => {
         addProject(projectRef)
+        // Create an unrestricted resolver (no include/exclude check) for
+        // referenced projects, so importers outside the reference's include
+        // scope can still use its path aliases.
+        if (!unrestrictedResolversByProject.has(projectRef)) {
+          const unrestricted = createResolver(projectRef, opts, logFile, true)
+          if (unrestricted) {
+            unrestrictedResolversByProject.set(projectRef, unrestricted)
+          }
+        }
       })
       // Ensure the latest directory data is used. One of the project
       // references may have updated it.
@@ -211,6 +221,7 @@ export function createTsconfigResolvers({
   const resetResolvers = () => {
     directoryCache = new Map()
     resolversByProject = new WeakMap()
+    unrestrictedResolversByProject = new WeakMap()
     initializing = loadEagerProjects()
   }
 
@@ -275,6 +286,19 @@ export function createTsconfigResolvers({
         const resolver = resolversByProject.get(project)
         if (resolver) {
           yield resolver
+        }
+        // When a project uses references (e.g., Nuxt, shared config
+        // packages), the referenced configs may live in sibling
+        // directories that are never visited by this ancestor walk.
+        // Yield their unrestricted resolvers (no include/exclude check)
+        // so imports from any directory can use referenced path aliases.
+        if (project.referenced) {
+          for (const ref of project.referenced) {
+            const refResolver = unrestrictedResolversByProject.get(ref)
+            if (refResolver) {
+              yield refResolver
+            }
+          }
         }
       }
     }
@@ -368,7 +392,8 @@ type ResolverOptions = {
 function createResolver(
   project: Project,
   opts: ResolverOptions,
-  logFile?: LogFileWriter | null
+  logFile?: LogFileWriter | null,
+  skipIncludeCheck?: boolean
 ): Resolver | null {
   const configPath = project.tsconfigFile
   const config = project.tsconfig
@@ -467,11 +492,14 @@ function createResolver(
       return notApplicable
     }
 
-    // Respect the include/exclude properties.
-    const relativeImporterFile = path.relative(configDir, importerFile)
-    if (!isIncludedRelative(relativeImporterFile)) {
-      logFile?.write('configMismatch', { importer, id, configPath })
-      return notApplicable
+    // Respect the include/exclude properties (skipped for referenced
+    // project resolvers, since the parent project's scope applies).
+    if (!skipIncludeCheck) {
+      const relativeImporterFile = path.relative(configDir, importerFile)
+      if (!isIncludedRelative(relativeImporterFile)) {
+        logFile?.write('configMismatch', { importer, id, configPath })
+        return notApplicable
+      }
     }
 
     // Find and remove special Vite queries (e.g. "?url") if present. If

--- a/test/__fixtures__/referenced-sibling/.config/tsconfig.app.json
+++ b/test/__fixtures__/referenced-sibling/.config/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "rootDir": "..",
+    "paths": {
+      "@/*": ["../app/*"]
+    }
+  },
+  "include": ["../app"]
+}

--- a/test/__fixtures__/referenced-sibling/app/log.ts
+++ b/test/__fixtures__/referenced-sibling/app/log.ts
@@ -1,0 +1,1 @@
+export const log = console.log.bind(console)

--- a/test/__fixtures__/referenced-sibling/config.json
+++ b/test/__fixtures__/referenced-sibling/config.json
@@ -1,0 +1,3 @@
+{
+  "tsconfig": ".config/tsconfig.app.json"
+}

--- a/test/__fixtures__/referenced-sibling/index.ts
+++ b/test/__fixtures__/referenced-sibling/index.ts
@@ -1,0 +1,3 @@
+import { log } from '@/log'
+
+log('Hello, world!')

--- a/test/__fixtures__/referenced-sibling/tsconfig.json
+++ b/test/__fixtures__/referenced-sibling/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.config/tsconfig.app.json"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #190.

## Summary

When a root tsconfig uses project references (e.g., Nuxt, shared config packages), the referenced configs may live in sibling directories (`.nuxt/`, `.config/`) that are never visited by the ancestor directory walk in `getResolvers`. Imports using aliases defined in those referenced projects fail with `configMismatch`.

**Example:** Nuxt generates `.nuxt/tsconfig.app.json` with path aliases like `@: ["../app"]`. A file at `tests/mytest.ts` importing `@/something` fails because:
1. The walk from `tests/` goes up to the project root
2. The root `tsconfig.json` has `"files": []` — skipped (no resolver created)
3. `.nuxt/tsconfig.app.json` is stored under `.nuxt/` in the cache — never visited

## Changes

**`getResolvers`** — when visiting a directory, also yield resolvers from referenced projects. This surfaces aliases from sibling directories without changing the walk itself.

**`createResolver`** — accepts a `skipIncludeCheck` flag. Referenced resolvers skip the include/exclude check since the parent project's scope applies rather than the reference's narrow include patterns (which typically only cover its own source files).

| File | Change |
|------|--------|
| `src/resolver.ts` | `getResolvers` yields referenced resolvers; `createResolver` supports `skipIncludeCheck`; `unrestrictedResolversByProject` WeakMap |
| `test/__fixtures__/referenced-sibling/` | Test fixture: root tsconfig with `files: []` referencing `.config/tsconfig.app.json` that defines `@/*` paths |

## Test plan

- [x] New `referenced-sibling` fixture passes (both tsc and Vite build)
- [x] All 7 existing test fixtures continue to pass
- [x] Verify with a real Nuxt project that uses `.nuxt/tsconfig.app.json` references