### PR TITLE
docs: note Vite 8 native tsconfig paths support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Give [`vite`] the ability to resolve imports using TypeScript's path mapping.
 > [!NOTE]
 > **New in v7** – Resolution engine replaced with [oxc-resolver](https://github.com/oxc-project/oxc-resolver) for significantly faster path resolution. Rolldown hook filters added for optimized performance under Rolldown-powered Vite. All existing plugin options and behavior are preserved. See the [Releases](https://github.com/aleclarson/vite-tsconfig-paths/releases) page for the full changelog.
 
+> [!TIP]
+> **Vite 8+** natively supports tsconfig path resolution via [`resolve.tsconfigPaths`](https://vite.dev/guide/features#paths). If you're on Vite 8 or later, you may not need this plugin — add `resolve: { tsconfigPaths: true }` to your Vite config instead. This plugin remains useful for Vite 5–7, or if you need features like lazy discovery, project references, or fine-grained control over which tsconfigs are used.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
Adds a tip callout explaining that Vite 8+ supports tsconfig path resolution natively via resolve.tsconfigPaths, with guidance on when this plugin is still useful (Vite 5-7, lazy discovery, project references, fine-grained control).

Addresses #214.